### PR TITLE
Fix createWDTocc crash on low ID ADTs

### DIFF
--- a/ADTConvert/Main.cs
+++ b/ADTConvert/Main.cs
@@ -169,7 +169,7 @@ namespace ADTConvert
                                 #region Create ADT tables
                                 if (inputIsDir)
                                 {
-                                    string newWorldName = Regex.Replace(adtName, @"(_\d{2}_\d{2}\.adt)", String.Empty);
+                                    string newWorldName = Regex.Replace(adtName, @"(_\d{1,}_\d{1,}\.adt)", String.Empty);
                                     if (worldName != newWorldName)
                                     {
                                         worldName = newWorldName;

--- a/ADTConvert/Main.cs
+++ b/ADTConvert/Main.cs
@@ -977,7 +977,7 @@ namespace ADTConvert
             foreach (var adt in adtList)
             {
                 string name = Path.GetFileNameWithoutExtension(adt);
-                var match = Regex.Match(name, @"_(\d{2})_(\d{2})$");
+                var match = Regex.Match(name, @"_(\d{1,})_(\d{1,})$");
                 UInt16 y = UInt16.Parse(match.Groups[1].ToString());
                 UInt16 x = UInt16.Parse(match.Groups[2].ToString());
 


### PR DESCRIPTION
createWDTocc crashed on encountering sub-10 adts (e.g. northrend_10_9) as it was looking for exactly 2 digits. Changed it to 1+ digits.